### PR TITLE
Add More Useful Emoji Commands

### DIFF
--- a/cogs/emote.py
+++ b/cogs/emote.py
@@ -43,10 +43,11 @@ class Emote(commands.Cog):
             print(f"HTTP Error {data.status} "
                   f"while getting {url}")
     
-    @commands.group()
+    @commands.group(aliases=['emoji'])
     async def emote(self, ctx):
         if ctx.invoked_subcommand is None:
             await ctx.send('You need to specify an emotetype.')
+            await ctx.send_help(ctx.command)
 
     @emote.command()
     async def noemote(self, ctx, url=None):
@@ -108,22 +109,24 @@ class Emote(commands.Cog):
         """Deletes an emoji from the guild.
         
         You must have Manage Emojis permission to use this.
-        
-        This is a case-sensitive command."""
-        if ctx.guild.id != emote.guild_id:
-            return await ctx.send("That emoji isn't in this guild!")
 
-        await emote.delete(reason=f"Emoji Removed by {ctx.author} (ID: {ctx.author.id})")
-        await ctx.send("Emote is now deleted.")
+        This is a case-sensitive command."""
+        if ctx.guild.id == emote.guild.id:
+            await emote.delete(reason=f"Emoji Removed by {ctx.author} (ID: {ctx.author.id})")
+            await ctx.send("Emote is now deleted.")
+        else:
+            return await ctx.send("That emote is not in this guild. "
+                                  "Run this command again in the guild that has that emote")
 
     @add.error
     @delete.error
     async def emoji_error(self, ctx, error):
         if isinstance(error, commands.MissingRequiredArgument):
-            await ctx.send('You gave incorrect arguments.')
+            await ctx.send(f'{ctx.author.mention}: You gave incorrect arguments.')
             return await ctx.send_help(ctx.command)
         elif isinstance(error, commands.CheckFailure):
-            return await ctx.send("You don't have the required permissions to use this command.")
+            return await ctx.send(f"{ctx.author.mention}: You don't have the required "
+                                  "permissions to use this command.")
         elif isinstance(error, commands.BadArgument):
             await ctx.send("Emoji not found.")
 

--- a/cogs/emote.py
+++ b/cogs/emote.py
@@ -85,12 +85,14 @@ class Emote(commands.Cog):
             if ctx.message.attachments:
                 emoji_aio = await self.aiosessionget(ctx.message.attachments[0].url)
             else:
-                return await ctx.send("❌ You need to provide a url or have an attachment on your message!")
+                return await ctx.send("❌ You need to provide a url or have an attachment on your message!\n"
+                                      f"Please see `{ctx.prefix}{ctx.command}` for more info.")
         else:
             try:
                 emoji_aio = await self.aiosessionget(url)
             except ValueError:
-                return await ctx.send("❌ You need to provide a url or have an attachment on your message!")
+                return await ctx.send("❌ You need to provide a url or have an attachment on your message!\n"
+                                      f"Please see `{ctx.prefix}{ctx.command}` for more info.")
 
         try:
             finalized_e = await ctx.guild.create_custom_emoji(name=emoji_name, image=emoji_aio, 
@@ -124,11 +126,15 @@ class Emote(commands.Cog):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send(f'{ctx.author.mention}: You gave incorrect arguments.')
             return await ctx.send_help(ctx.command)
+        elif isinstance(error, commands.BotMissingPermissions):
+            rn = '\n-'.join(error.missing_perms)
+            return await ctx.send("Bot is missing permissions. Please add the following permissions\n"
+                                  f"`- {rn}`")
         elif isinstance(error, commands.CheckFailure):
             return await ctx.send(f"{ctx.author.mention}: You don't have the required "
                                   "permissions to use this command.")
         elif isinstance(error, commands.BadArgument):
-            await ctx.send("Emoji not found.")
+            return await ctx.send("Emoji not found.")
 
     @commands.Cog.listener()
     async def on_guild_emojis_update(self, guild, before, after):

--- a/cogs/emote.py
+++ b/cogs/emote.py
@@ -129,7 +129,7 @@ class Emote(commands.Cog):
         elif isinstance(error, commands.BotMissingPermissions):
             rn = '\n-'.join(error.missing_perms)
             return await ctx.send("Bot is missing permissions. Please add the following permissions\n"
-                                  f"`- {rn}`")
+                                  f"```- {rn}```")
         elif isinstance(error, commands.CheckFailure):
             return await ctx.send(f"{ctx.author.mention}: You don't have the required "
                                   "permissions to use this command.")

--- a/cogs/emote.py
+++ b/cogs/emote.py
@@ -75,6 +75,7 @@ class Emote(commands.Cog):
         await ctx.send(file=image)
 
     @emote.command()
+    @commands.guild_only()
     @commands.bot_has_permissions(manage_emojis=True)
     @checks.check_permissions_or_owner(manage_emojis=True)
     async def add(self, ctx, emoji_name: str, url=None):
@@ -105,6 +106,7 @@ class Emote(commands.Cog):
         await ctx.send(f"Successfully created {finalized_e} -- `{finalized_e}`")
 
     @emote.command()
+    @commands.guild_only()
     @commands.bot_has_permissions(manage_emojis=True)
     @checks.check_permissions_or_owner(manage_emojis=True)
     async def delete(self, ctx, emote: discord.Emoji):
@@ -126,6 +128,8 @@ class Emote(commands.Cog):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send(f'{ctx.author.mention}: You gave incorrect arguments.')
             return await ctx.send_help(ctx.command)
+        elif isinstance(error, commands.NoPrivateMessage):
+            return await ctx.send("This command cannot be run in DMs!")
         elif isinstance(error, commands.BotMissingPermissions):
             rn = '\n-'.join(error.missing_perms)
             return await ctx.send("Bot is missing permissions. Please add the following permissions\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyyaml
-git+https://github.com/Rapptz/discord.py@rewrite
+discord.py


### PR DESCRIPTION
- Vital fix for cogs on the latest d.py
- Adds on_guild_emojis_update listener 
No longer need to type a new emote in the emote-list channel as the bot does it for you
![Example](https://btw.i-use-ar.ch/i/nsb1.png)
- Handles various errors
- Adds `.emote add` and `.emote delete` (Command Author Needs to Have Manage Emoji Permissions)
- Added alias to `.emote` as `.emoji`
